### PR TITLE
Change password min length to 15

### DIFF
--- a/src/sse/settings.py
+++ b/src/sse/settings.py
@@ -70,6 +70,9 @@ AUTH_PASSWORD_VALIDATORS = [
     },
     {
         'NAME': 'django.contrib.auth.password_validation.MinimumLengthValidator',
+        "OPTIONS": {
+                    "min_length": 15,
+                },
     },
     {
         'NAME': 'django.contrib.auth.password_validation.CommonPasswordValidator',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated password validation requirements. The minimum password length for all user accounts has been increased to 15 characters. This new requirement applies when users create new accounts and when resetting existing account passwords. Users should ensure their passwords comply with this updated standard.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->