### PR TITLE
Filter iframe src so that only youtube links are allowed

### DIFF
--- a/src/notes/utils.py
+++ b/src/notes/utils.py
@@ -21,10 +21,15 @@ ALLOWED_TAGS = [
     'div', 'button', 'template'
 ]
 
+def iframe_attribute_filter(tag, name, value):
+    if name == 'src':
+        return value.startswith('https://www.youtube-nocookie.com/embed/')
+    return name in ['title', 'referrerpolicy', 'frameborder', 'allowfullscreen']
+
 ALLOWED_ATTRIBUTES = {
     'a': ['href', 'title'],
     'img': ['src', 'alt', 'title'],
-    'iframe': ['src', 'title', 'allow', 'referrerpolicy', 'frameborder'],
+    'iframe': iframe_attribute_filter,
     'div': ['class']
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Improvements**
  * Restricted iframe embeds to YouTube nocookie sources for enhanced security
  * Implemented stricter attribute validation for embedded content

* **Features**
  * Enabled fullscreen support for embedded iframes
  * Expanded iframe property support including title, referrerpolicy, frameborder, and allowfullscreen

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->