### PR TITLE
Change mititgation sentence for the search note function

### DIFF
--- a/docs/docs/core-features.md
+++ b/docs/docs/core-features.md
@@ -311,9 +311,7 @@ The note search functionality is implemented via a custom `search_note` view tha
 If access control checks are missing or incorrect, users could see
 notes they do not own, including private notes of other users.
 
-Mitigation: Use the ORM `filter()` function to ensure only public notes
-are returned and `user.notes.all()` to include all notes owned by the
-authenticated user.
+Mitigation: Use the ORM `filter()` function to ensure that only notes belonging to the authenticated user are returned.
 
 **Cross-Site Scripting (XSS)**
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Note Search mitigation guidance and access control documentation. Search results will now display exclusively notes belonging to the authenticated user, with public notes from other users no longer included in results. This change modifies the search visibility scope and updates access control parameters governing which notes are displayed during search operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->